### PR TITLE
vmh264: don't force deinterlacing

### DIFF
--- a/drivers/frame_provider/decoder/h264_multi/vmh264.c
+++ b/drivers/frame_provider/decoder/h264_multi/vmh264.c
@@ -136,9 +136,7 @@ unsigned int h264_debug_cmd;
 
 static int ref_b_frame_error_max_count = 50;
 
-static unsigned int dec_control =
-	DEC_CONTROL_FLAG_FORCE_2997_1080P_INTERLACE |
-	DEC_CONTROL_FLAG_FORCE_2500_576P_INTERLACE;
+static unsigned int dec_control = 0;
 
 static unsigned int force_rate_streambase;
 static unsigned int force_rate_framebase;


### PR DESCRIPTION
Some progressive 1080p25 content is currently processed as 1080i50. Forcing deinterlacer on progressive content looks bad - I suggest this patch to disable this behaviour and let Kodi decide when to turn on deinterlacing.

Example of content (requires IA + widevine): [bitmovin.strm.txt](https://github.com/CoreELEC/xbmc/files/6413314/bitmovin.strm.txt) (remove `txt` from extension)

After `echo 0 > /sys/module/amvdec_mh264/parameters/dec_control` above video looks better and the real progressive 25fps is displayed.