### PR TITLE
Workaround for ATEME Titan created HEVC ES - where existing logic cannot determine the SEI Mastering Display Colour Volume and Content Light Level

### DIFF
--- a/drivers/frame_provider/decoder/h265/vh265.c
+++ b/drivers/frame_provider/decoder/h265/vh265.c
@@ -8585,8 +8585,9 @@ static int parse_sei(struct hevc_state_s *hevc,
 	char *p = sei_buf;
 	char *p_sei;
 	uint16_t header;
-	uint8_t nal_unit_type;
-	uint8_t payload_type, payload_size;
+	uint16_t nal_unit_type;
+	uint16_t payload_type = 0;
+	uint16_t payload_size = 0;
 	int i, j;
 
 	if (size < 2)
@@ -8598,9 +8599,21 @@ static int parse_sei(struct hevc_state_s *hevc,
 	if ((nal_unit_type != NAL_UNIT_SEI)
 	&& (nal_unit_type != NAL_UNIT_SEI_SUFFIX))
 		return 0;
-	while (p+2 <= sei_buf+size) {
+	while (p+4 <= sei_buf+size) {
+		payload_type = 0;
+		payload_size = 0;
+		while (*p == 0xff) {
+			payload_type += *p++;
+		}
 		payload_type = *p++;
+
+		while (*p == 0xff) {
+			payload_size += *p++;
+		}
 		payload_size = *p++;
+		if (payload_size == 0)
+			break;	
+		
 		if (p+payload_size <= sei_buf+size) {
 			switch (payload_type) {
 			case SEI_PicTiming:


### PR DESCRIPTION
Add a special Parser to find ATEME Titan HEVC ES - SEI Mastering Display Colour Volume and Content Light Level

parse_sei not working correctly with this data, hence separate parser for now until that is fixed.

This parse will look for the ATEME string (would be inside the user data SEI which appears missing the payload type)
Then attempts to find the exact type and size for SEI Mastering Display Colour Volume
Then attempts to find the exact type and size for SEI Content Light Level, exactly after the SEI MDCV
Only if both SEI are found in the above in the exact order then can be considered good to process.