### PR TITLE
h265: raise default dynamic_buf_num_margin 8->12

### DIFF
--- a/drivers/frame_provider/decoder/h265/vh265.c
+++ b/drivers/frame_provider/decoder/h265/vh265.c
@@ -395,7 +395,7 @@ static u32 run_ready_display_q_num;
 static u32 run_ready_max_buf_num = 0xff;
 #endif
 
-static u32 dynamic_buf_num_margin = 8;
+static u32 dynamic_buf_num_margin = 12;
 static u32 interlace_filed_margin = 6;
 
 static u32 buf_alloc_width;


### PR DESCRIPTION
Dual-layer (profile 7) Dolby Vision stutters randomly, sometimes a few times per minute. The base and enhancement layers decode as one stream, so at moments the decoder's output queue briefly empties and the picture freezes for a frame, as if the EL layer decode was late.

Holding a few more decoded frames (margin 8 -> 12) looks to cover the gap. Tested on AM6B+ (S922X): stutters are way improved, no visible dropped frames.