### PR TITLE
vdec: fix two teardown races on stop/seek

### DIFF
--- a/drivers/frame_provider/decoder/h265/vh265.c
+++ b/drivers/frame_provider/decoder/h265/vh265.c
@@ -15509,17 +15509,20 @@ static void reset(struct vdec_s *vdec)
 		(struct hevc_state_s *)vdec->private;
 	int i;
 
-	cancel_work_sync(&hevc->work);
-	cancel_work_sync(&hevc->notify_work);
+	if (hevc->stat & STAT_TIMER_ARM) {
+		del_timer_sync(&hevc->timer);
+		hevc->stat &= ~STAT_TIMER_ARM;
+	}
+
 	if (hevc->stat & STAT_VDEC_RUN) {
 		amhevc_stop();
 		hevc->stat &= ~STAT_VDEC_RUN;
 	}
 
-	if (hevc->stat & STAT_TIMER_ARM) {
-		del_timer_sync(&hevc->timer);
-		hevc->stat &= ~STAT_TIMER_ARM;
-	}
+	cancel_work_sync(&hevc->notify_work);
+	cancel_work_sync(&hevc->set_clk_work);
+	cancel_work_sync(&hevc->timeout_work);
+	cancel_work_sync(&hevc->work);
 	hevc->dec_result = DEC_RESULT_NONE;
 	hevc->timeout_flag = TIMEOUT_INIT;
 	reset_process_time(hevc);

--- a/drivers/frame_provider/decoder/utils/vdec.c
+++ b/drivers/frame_provider/decoder/utils/vdec.c
@@ -3998,6 +3998,7 @@ static void vdec_connect_list_force_clear(struct vdec_core_s *core, struct vdec_
 	struct vdec_s *vdec, *tmp;
 	unsigned long flags;
 
+	mutex_lock(&vdec_mutex);
 	flags = vdec_core_lock(core);
 
 	list_for_each_entry_safe(vdec, tmp,
@@ -4027,6 +4028,7 @@ static void vdec_connect_list_force_clear(struct vdec_core_s *core, struct vdec_
 	}
 
 	vdec_core_unlock(core, flags);
+	mutex_unlock(&vdec_mutex);
 }
 
 st_userdata *get_vdec_userdata_ctx(void)


### PR DESCRIPTION
Two small races in decoder teardown, both can bite when stopping, seeking or switching streams:
- vh265: reset ran before the timeout watchdog was stopped and pending work was cancelled (timeout_work was never cancelled at all), so the watchdog could still poke the decoder mid-reset. 
- vdec: the connect_list force clear didn't take the lock the readers use, so the list could get corrupted. Take the lock.